### PR TITLE
Update GitHub scm links

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -63,10 +63,10 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)
 systemProp.org.gradle.internal.http.socketTimeout=120000
 
-POM_URL=https://github.com/skydoves/flexible-bottomsheet/
-POM_SCM_URL=https://github.com/skydoves/flexible-bottomsheet/
-POM_SCM_CONNECTION=scm:git:git://github.com/skydoves/flexible-bottomsheet.git
-POM_SCM_DEV_CONNECTION=scm:git:git://github.com/skydoves/flexible-bottomsheet.git
+POM_URL=https://github.com/skydoves/FlexibleBottomSheet
+POM_SCM_URL=https://github.com/skydoves/FlexibleBottomSheet
+POM_SCM_CONNECTION=scm:git:git://github.com/skydoves/FlexibleBottomSheet.git
+POM_SCM_DEV_CONNECTION=scm:git:git://github.com/skydoves/FlexibleBottomSheet.git
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
The scm url links are pointing to a non-existing repository https://github.com/skydoves/flexible-bottomsheet, which prevents tools like https://klibs.io from indexing it correctly