### PR TITLE
Remove check for sheetState.isModal from onDragging lambda

### DIFF
--- a/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
+++ b/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
@@ -259,9 +259,7 @@ public fun FlexibleBottomSheet(
                   screenHeight = screenHeightSize.value,
                   onFling = settleToDismiss,
                   onDragging = {
-                    if (!sheetState.isModal) {
-                      isDragging = it
-                    }
+                    isDragging = it
                   },
                 )
               } else {


### PR DESCRIPTION
### Types of changes
- skydoves/FlexibleBottomSheet/issues/30 Bugfix (non-breaking change which fixes an issue)

This PR is about to fix FlexibleBottomSheet's visibility (flashing) issue when using a scrollable element in it. The issue is happening only for Modal versions and to address that removed an if check assigning isDragging to the value captured in onDragging lambda.

**Bug evidence:** 

https://github.com/user-attachments/assets/bfeccc50-5073-4d4d-b709-c7731e6141ad

**Resolved evidence:**

https://github.com/user-attachments/assets/fb1cd475-5318-4a19-b72a-7d271e34a869

**Minimum reproducable example:**
```kotlin
@Composable
fun BugReproduceExample(
  onDismiss: () -> Unit
) {
  val sheetState = rememberFlexibleBottomSheetState(
    isModal = true,
  )

  FlexibleBottomSheet(
    onDismissRequest = onDismiss,
    sheetState = sheetState
  ) {

    Column(
      modifier = Modifier
          .padding(horizontal = 20.dp)
          .verticalScroll(rememberScrollState()),
    ) {
      repeat(50) {
        Text(text = "Text in scrollable column", style = MaterialTheme.typography.headlineLarge)
        Spacer(Modifier.height(16.dp))
      }
    }
  }
}
```

