### PR TITLE
Bug fix: When restoring the Sheet with rememberSaveable(), the dispaly state of the Sheet is incorrect

### DIFF
--- a/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetState.kt
+++ b/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetState.kt
@@ -194,9 +194,14 @@ public class FlexibleSheetState(
   /**
    * Expand the bottom sheet with animation and suspend until it is [FlexibleSheetValue.IntermediatelyExpanded] if defined
    * else [FlexibleSheetValue.FullyExpanded].
+   * If the current state is not FlexibleSheetValue.Hidden,
+   * calling this function without set the [target] parameter will retain the current state.
    * @throws [CancellationException] if the animation is interrupted
    */
   public suspend fun show(target: FlexibleSheetValue? = null) {
+    if (target == null && currentValue != FlexibleSheetValue.Hidden) {
+      return
+    }
     if (!isModal) {
       val targetValue1 = when {
         hasIntermediatelyExpandedState -> FlexibleSheetValue.IntermediatelyExpanded


### PR DESCRIPTION

This PR targets the show() function in FlexibleSheetState. By adding a check for the current state to determine whether to execute updates to the state and animations.

### Types of changes
Bugfix (non-breaking change which fixes an issue), issue detail: #48  This issue was also raised by me.

This PR has passed the gradle check

after change :
https://github.com/user-attachments/assets/efd7c4dd-3959-497b-955d-2cf74803f1fc

