### PR TITLE
Add `collapseOnFlingDown` parameter to FlexibleSheetState

### DIFF
--- a/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/FlexibleBottomSheetSample1.kt
+++ b/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/FlexibleBottomSheetSample1.kt
@@ -40,9 +40,7 @@ fun FlexibleBottomSheetSample1(
   onDismissRequest: () -> Unit,
 ) {
   var currentSheetTarget by remember { mutableStateOf(FlexibleSheetValue.IntermediatelyExpanded) }
-  val systemUiController = rememberSystemUiController()
 
-  val primaryColor = MaterialTheme.colorScheme.primary
   val scrimColor = Color.Black.copy(alpha = 0.65f)
 
   FlexibleBottomSheet(
@@ -54,15 +52,6 @@ fun FlexibleBottomSheetSample1(
     ),
     onTargetChanges = { sheetValue ->
       currentSheetTarget = sheetValue
-      if (sheetValue == FlexibleSheetValue.Hidden) {
-        systemUiController.setStatusBarColor(
-          color = primaryColor,
-        )
-      } else {
-        systemUiController.setStatusBarColor(
-          color = scrimColor,
-        )
-      }
     },
     containerColor = Color.Black,
     scrimColor = scrimColor,

--- a/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/MainActivity.kt
+++ b/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/MainActivity.kt
@@ -19,12 +19,16 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -41,6 +45,7 @@ import com.skydoves.flexiblebottomsheetdemo.ui.theme.FlexibleBottomSheetDemoThem
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
 
     setContent {
       var isShowingBottomSheet1 by remember { mutableStateOf(false) }
@@ -48,7 +53,7 @@ class MainActivity : ComponentActivity() {
       var isShowingBottomSheet3 by remember { mutableStateOf(false) }
 
       FlexibleBottomSheetDemoTheme {
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize().windowInsetsPadding(WindowInsets.systemBars)) {
           Column(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.Top,

--- a/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/ui/theme/Theme.kt
@@ -68,14 +68,6 @@ fun FlexibleBottomSheetDemoTheme(
     darkTheme -> DarkColorScheme
     else -> LightColorScheme
   }
-  val view = LocalView.current
-  if (!view.isInEditMode) {
-    SideEffect {
-      val window = (view.context as Activity).window
-      window.statusBarColor = colorScheme.primary.toArgb()
-      WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-    }
-  }
 
   MaterialTheme(
     colorScheme = colorScheme,

--- a/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetState.kt
+++ b/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetState.kt
@@ -52,6 +52,7 @@ import kotlin.math.min
  * will be dismissed upon touching outside of the sheet. If set to false, the bottom sheet allows interaction with the screen, permitting actions outside of the sheet.
  * expand to the [FlexibleSheetValue.FullyExpanded] state and move to the [FlexibleSheetValue.IntermediatelyExpanded] if available, either
  * programmatically or by user interaction.
+ * @param collapseOnFlingDown Determines if the bottom sheet should be collapsed to a suitable state on any downward fling gesture.
  */
 @Stable
 public class FlexibleSheetState(
@@ -62,6 +63,7 @@ public class FlexibleSheetState(
   public val containSystemBars: Boolean,
   public val allowNestedScroll: Boolean,
   public val isModal: Boolean,
+  public val collapseOnFlingDown: Boolean,
   public val animateSpec: AnimationSpec<Float>,
   initialValue: FlexibleSheetValue = FlexibleSheetValue.Hidden,
   confirmValueChange: (FlexibleSheetValue) -> Boolean = { true },
@@ -304,6 +306,7 @@ public class FlexibleSheetState(
       containSystemBars: Boolean,
       allowNestedScroll: Boolean,
       isModal: Boolean,
+      collapseOnFlingDown: Boolean,
       animateSpec: AnimationSpec<Float>,
       confirmValueChange: (FlexibleSheetValue) -> Boolean,
     ) = Saver<FlexibleSheetState, FlexibleSheetValue>(
@@ -314,6 +317,7 @@ public class FlexibleSheetState(
           skipIntermediatelyExpanded = skipIntermediatelyExpanded,
           skipSlightlyExpanded = skipSlightlyExpanded,
           isModal = isModal,
+          collapseOnFlingDown = collapseOnFlingDown,
           initialValue = savedValue,
           animateSpec = animateSpec,
           flexibleSheetSize = flexibleSheetSize,
@@ -376,7 +380,7 @@ public fun consumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
     return if (delta < 0 && source == NestedScrollSource.Drag) {
       onDragging.invoke(true)
       sheetState.swipeableState.dispatchRawDelta(delta).toOffset()
-    } else if (delta > 0 && source == NestedScrollSource.Fling && !sheetState.isModal) {
+    } else if (delta > 0 && source == NestedScrollSource.Fling && sheetState.collapseOnFlingDown) {
       onDragging.invoke(true)
 
       val currentOffset = sheetState.swipeableState.dispatchRawDelta(delta)
@@ -461,6 +465,7 @@ public fun consumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
  * @param allowNestedScroll Whether the bottom sheet should allow the content to implement nested scrolling.
  * @param isModal Determines if the bottom sheet should be modal. If set to true, the sheet will include a scrim overlaying the background and
  * will be dismissed upon touching outside of the sheet. If set to false, the bottom sheet allows interaction with the screen, permitting actions outside of the sheet.
+ * @param collapseOnFlingDown Determines if the bottom sheet should be collapsed to a suitable state on any downward fling gesture.
  * @param flexibleSheetSize FlexibleSheetSize constraints the content size of [FlexibleBottomSheet] based on its states.
  * @param confirmValueChange Optional callback invoked to confirm or veto a pending state change.
  */
@@ -470,6 +475,7 @@ public fun rememberFlexibleBottomSheetState(
   skipIntermediatelyExpanded: Boolean = false,
   skipSlightlyExpanded: Boolean = true,
   isModal: Boolean = false,
+  collapseOnFlingDown: Boolean = !isModal,
   containSystemBars: Boolean = false,
   allowNestedScroll: Boolean = true,
   animateSpec: AnimationSpec<Float> = SwipeableV2Defaults.AnimationSpec,
@@ -486,6 +492,7 @@ public fun rememberFlexibleBottomSheetState(
   skipIntermediatelyExpanded = skipIntermediatelyExpanded,
   skipSlightlyExpanded = skipSlightlyExpanded,
   isModal = isModal,
+  collapseOnFlingDown = collapseOnFlingDown,
   animateSpec = animateSpec,
   confirmValueChange = confirmValueChange,
   flexibleSheetSize = flexibleSheetSize,
@@ -499,6 +506,7 @@ private fun rememberFlexibleSheetState(
   skipIntermediatelyExpanded: Boolean = false,
   skipSlightlyExpanded: Boolean = false,
   isModal: Boolean = true,
+  collapseOnFlingDown: Boolean = !isModal,
   confirmValueChange: (FlexibleSheetValue) -> Boolean = { true },
   animateSpec: AnimationSpec<Float> = SwipeableV2Defaults.AnimationSpec,
   initialValue: FlexibleSheetValue = FlexibleSheetValue.Hidden,
@@ -516,6 +524,7 @@ private fun rememberFlexibleSheetState(
       skipIntermediatelyExpanded = skipIntermediatelyExpanded,
       skipSlightlyExpanded = skipSlightlyExpanded,
       isModal = isModal,
+      collapseOnFlingDown = collapseOnFlingDown,
       animateSpec = animateSpec,
       flexibleSheetSize = flexibleSheetSize,
       containSystemBars = containSystemBars,
@@ -528,6 +537,7 @@ private fun rememberFlexibleSheetState(
       skipIntermediatelyExpanded = skipIntermediatelyExpanded,
       skipSlightlyExpanded = skipSlightlyExpanded,
       isModal = isModal,
+      collapseOnFlingDown = collapseOnFlingDown,
       initialValue = initialValue,
       animateSpec = animateSpec,
       confirmValueChange = confirmValueChange,


### PR DESCRIPTION
Introduce the `collapseOnFlingDown` property to control whether the bottom sheet collapses on a downward fling gesture. Updated constructors, property initializations, and logic to use this parameter, ensuring greater flexibility for sheet behavior customization.

```kotlin
val sheetState = rememberFlexibleBottomSheetState(
  collapseOnFlingDown = false //by default = !isModal
)
```

Before, the behavior depended on type of the bottom sheet: 
 - for `isModal=true` downward fling gestures didn't collapse the bottomsheet unless inner scroll is ended
 - for `isModal=false` the gestures always collapsed the bottomsheet to the possible smaller state



You will see the difference below:

`collapseOnFlingDown = true` | `collapseOnFlingDown = false` |
| :---------------: | :---------------: |
| <video src="https://github.com/user-attachments/assets/5dae2ca8-0a57-4037-a106-a61ea61e847f" type="video/mp4"/> | <video src="https://github.com/user-attachments/assets/78bf60f4-8893-416b-bbef-c71507b74419" type="video/mp4"/> |



