### PR TITLE
Fix: Bottom sheet appearing above navigation drawer (Issue #75)

### DIFF
--- a/app/api/app.api
+++ b/app/api/app.api
@@ -16,10 +16,13 @@ public final class com/skydoves/flexiblebottomsheetdemo/ComposableSingletons$Fle
 public final class com/skydoves/flexiblebottomsheetdemo/ComposableSingletons$MainActivityKt {
 	public static final field INSTANCE Lcom/skydoves/flexiblebottomsheetdemo/ComposableSingletons$MainActivityKt;
 	public fun <init> ()V
-	public final fun getLambda$-1405033129$app_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-1785979185$app_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1422763669$app_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-15734029$app_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1274917780$app_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$2032147935$app_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$417458574$app_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$20907218$app_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2117507764$app_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$439005230$app_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/flexiblebottomsheetdemo/FlexibleBottomSheetSample1Kt {

--- a/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/FlexibleBottomSheetSample1.kt
+++ b/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/FlexibleBottomSheetSample1.kt
@@ -54,6 +54,7 @@ fun FlexibleBottomSheetSample1(
         slightlyExpanded = FlexibleSheetSize.WrapContent,
       ),
       isModal = true,
+      usePopup = false, // Render inline - drawer will appear above bottom sheet
       skipSlightlyExpanded = false,
     ),
     onTargetChanges = { sheetValue ->

--- a/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/FlexibleBottomSheetSample2.kt
+++ b/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/FlexibleBottomSheetSample2.kt
@@ -65,6 +65,7 @@ fun FlexibleBottomSheetSample2(
       slightlyExpanded = 0.18f,
     ),
     isModal = false,
+    usePopup = false, // Render inline - drawer will appear above bottom sheet
     skipSlightlyExpanded = false,
   )
 

--- a/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/MainActivity.kt
+++ b/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/MainActivity.kt
@@ -26,18 +26,30 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
+import androidx.compose.material.DrawerValue
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.ModalDrawer
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.skydoves.flexiblebottomsheetdemo.ui.theme.FlexibleBottomSheetDemoTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -48,64 +60,95 @@ class MainActivity : ComponentActivity() {
       var isShowingBottomSheet1 by remember { mutableStateOf(false) }
       var isShowingBottomSheet2 by remember { mutableStateOf(false) }
       var isShowingBottomSheet3 by remember { mutableStateOf(false) }
+      val drawerState = rememberDrawerState(DrawerValue.Closed)
+      val scope = rememberCoroutineScope()
 
       FlexibleBottomSheetDemoTheme {
-        Box(modifier = Modifier.fillMaxSize()) {
-          Column(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.Top,
-            horizontalAlignment = Alignment.CenterHorizontally,
-          ) {
-            TestButton(title = "Show a Toast 1")
-
-            Spacer(modifier = Modifier.height(30.dp))
-
-            Button(
-              onClick = {
-                isShowingBottomSheet1 = !isShowingBottomSheet1
-              },
+        ModalDrawer(
+          drawerState = drawerState,
+          drawerContent = {
+            Column(
+              modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
             ) {
-              Text(text = "Show Flexible Modal Sheet")
+              Spacer(modifier = Modifier.height(48.dp))
+              Text(text = "Drawer Content")
+              Spacer(modifier = Modifier.height(16.dp))
+              Text(text = "If the fix works, this drawer should appear ABOVE the bottom sheet")
             }
+          },
+        ) {
+          Scaffold(
+            topBar = {
+              TopAppBar(
+                title = { Text("FlexibleBottomSheet Demo") },
+                navigationIcon = {
+                  IconButton(onClick = { scope.launch { drawerState.open() } }) {
+                    Icon(Icons.Default.Menu, contentDescription = "Menu")
+                  }
+                },
+              )
+            },
+          ) { paddingValues ->
+            Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+              Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Top,
+                horizontalAlignment = Alignment.CenterHorizontally,
+              ) {
+                TestButton(title = "Show a Toast 1")
 
-            Button(
-              onClick = {
-                isShowingBottomSheet2 = !isShowingBottomSheet2
-              },
-            ) {
-              Text(text = "Show Flexible Non Modal Sheet")
-            }
+                Spacer(modifier = Modifier.height(30.dp))
 
-            Button(
-              onClick = {
-                isShowingBottomSheet3 = !isShowingBottomSheet3
-              },
-            ) {
-              Text(text = "Show Dynamic Content Sheet")
-            }
+                Button(
+                  onClick = {
+                    isShowingBottomSheet1 = !isShowingBottomSheet1
+                  },
+                ) {
+                  Text(text = "Show Flexible Modal Sheet")
+                }
 
-            TestButton(title = "Show a Toast 3")
+                Button(
+                  onClick = {
+                    isShowingBottomSheet2 = !isShowingBottomSheet2
+                  },
+                ) {
+                  Text(text = "Show Flexible Non Modal Sheet")
+                }
 
-            TestButton(title = "Show a Toast 4")
+                Button(
+                  onClick = {
+                    isShowingBottomSheet3 = !isShowingBottomSheet3
+                  },
+                ) {
+                  Text(text = "Show Dynamic Content Sheet")
+                }
 
-            TestButton(title = "Show a Toast 5")
-          }
+                TestButton(title = "Show a Toast 3")
 
-          if (isShowingBottomSheet1) {
-            FlexibleBottomSheetSample1 {
-              isShowingBottomSheet1 = false
-            }
-          }
+                TestButton(title = "Show a Toast 4")
 
-          if (isShowingBottomSheet2) {
-            FlexibleBottomSheetSample2 {
-              isShowingBottomSheet2 = false
-            }
-          }
+                TestButton(title = "Show a Toast 5")
+              }
 
-          if (isShowingBottomSheet3) {
-            FlexibleBottomSheetSample3 {
-              isShowingBottomSheet3 = false
+              if (isShowingBottomSheet1) {
+                FlexibleBottomSheetSample1 {
+                  isShowingBottomSheet1 = false
+                }
+              }
+
+              if (isShowingBottomSheet2) {
+                FlexibleBottomSheetSample2 {
+                  isShowingBottomSheet2 = false
+                }
+              }
+
+              if (isShowingBottomSheet3) {
+                FlexibleBottomSheetSample3 {
+                  isShowingBottomSheet3 = false
+                }
+              }
             }
           }
         }

--- a/flexible-bottomsheet-material/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material/FlexibleBottomSheet.kt
+++ b/flexible-bottomsheet-material/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material/FlexibleBottomSheet.kt
@@ -17,6 +17,7 @@ package com.skydoves.flexible.bottomsheet.material
 
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -157,24 +158,7 @@ public fun FlexibleBottomSheet(
       ).size
   }
 
-  FlexibleBottomSheetPopup(
-    onDismissRequest = {
-      onBackPressed.invoke()
-      if (sheetState.currentValue == FlexibleSheetValue.FullyExpanded &&
-        sheetState.hasIntermediatelyExpandedState
-      ) {
-        scope.launch { sheetState.intermediatelyExpand() }
-      } else if (sheetState.currentValue == FlexibleSheetValue.IntermediatelyExpanded &&
-        sheetState.hasSlightlyExpandedState
-      ) {
-        scope.launch { sheetState.slightlyExpand() }
-      } else { // Is expanded without collapsed state or is collapsed.
-        scope.launch { sheetState.hide() }.invokeOnCompletion { onDismissRequest() }
-      }
-    },
-    sheetState = sheetState,
-    windowInsets = windowInsets,
-  ) {
+  val sheetContent: @Composable BoxScope.() -> Unit = {
     var isDragging by remember { mutableStateOf(false) }
     val isAnimationRunning = sheetState.swipeableState.isAnimationRunning
     val screenHeightSize = screenHeight()
@@ -405,6 +389,35 @@ public fun FlexibleBottomSheet(
       }
     }
   }
+
+  // Conditionally use popup or render inline based on sheetState.usePopup
+  if (sheetState.usePopup) {
+    FlexibleBottomSheetPopup(
+      onDismissRequest = {
+        onBackPressed.invoke()
+        if (sheetState.currentValue == FlexibleSheetValue.FullyExpanded &&
+          sheetState.hasIntermediatelyExpandedState
+        ) {
+          scope.launch { sheetState.intermediatelyExpand() }
+        } else if (sheetState.currentValue == FlexibleSheetValue.IntermediatelyExpanded &&
+          sheetState.hasSlightlyExpandedState
+        ) {
+          scope.launch { sheetState.slightlyExpand() }
+        } else { // Is expanded without collapsed state or is collapsed.
+          scope.launch { sheetState.hide() }.invokeOnCompletion { onDismissRequest() }
+        }
+      },
+      sheetState = sheetState,
+      windowInsets = windowInsets,
+      content = sheetContent,
+    )
+  } else {
+    // Render inline without popup - respects z-order of navigation drawers
+    Box(modifier = Modifier.fillMaxSize()) {
+      sheetContent()
+    }
+  }
+
   if (sheetState.hasFullyExpandedState) {
     LaunchedEffect(sheetState) {
       sheetState.show()

--- a/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
+++ b/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
@@ -17,6 +17,7 @@ package com.skydoves.flexible.bottomsheet.material3
 
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -160,24 +161,7 @@ public fun FlexibleBottomSheet(
       ).size
   }
 
-  FlexibleBottomSheetPopup(
-    onDismissRequest = {
-      if (sheetState.currentValue == FlexibleSheetValue.FullyExpanded &&
-        sheetState.hasIntermediatelyExpandedState
-      ) {
-        scope.launch { sheetState.intermediatelyExpand() }
-      } else if (sheetState.currentValue == FlexibleSheetValue.IntermediatelyExpanded &&
-        sheetState.hasSlightlyExpandedState
-      ) {
-        scope.launch { sheetState.slightlyExpand() }
-      } else { // Is expanded without collapsed state or is collapsed.
-        scope.launch { sheetState.hide() }.invokeOnCompletion { onDismissRequest() }
-      }
-      onBackPressed.invoke()
-    },
-    sheetState = sheetState,
-    windowInsets = windowInsets,
-  ) {
+  val sheetContent: @Composable BoxScope.() -> Unit = {
     var isDragging by remember { mutableStateOf(false) }
     val isAnimationRunning = sheetState.swipeableState.isAnimationRunning
     val screenHeightSize = screenHeight()
@@ -409,6 +393,35 @@ public fun FlexibleBottomSheet(
       }
     }
   }
+
+  // Conditionally use popup or render inline based on sheetState.usePopup
+  if (sheetState.usePopup) {
+    FlexibleBottomSheetPopup(
+      onDismissRequest = {
+        if (sheetState.currentValue == FlexibleSheetValue.FullyExpanded &&
+          sheetState.hasIntermediatelyExpandedState
+        ) {
+          scope.launch { sheetState.intermediatelyExpand() }
+        } else if (sheetState.currentValue == FlexibleSheetValue.IntermediatelyExpanded &&
+          sheetState.hasSlightlyExpandedState
+        ) {
+          scope.launch { sheetState.slightlyExpand() }
+        } else { // Is expanded without collapsed state or is collapsed.
+          scope.launch { sheetState.hide() }.invokeOnCompletion { onDismissRequest() }
+        }
+        onBackPressed.invoke()
+      },
+      sheetState = sheetState,
+      windowInsets = windowInsets,
+      content = sheetContent,
+    )
+  } else {
+    // Render inline without popup - respects z-order of navigation drawers
+    Box(modifier = Modifier.fillMaxSize()) {
+      sheetContent()
+    }
+  }
+
   if (sheetState.hasFullyExpandedState) {
     LaunchedEffect(sheetState) {
       sheetState.show()

--- a/flexible-core/api/android/flexible-core.api
+++ b/flexible-core/api/android/flexible-core.api
@@ -34,8 +34,8 @@ public final class com/skydoves/flexible/core/FlexibleSheetSize$Companion {
 
 public final class com/skydoves/flexible/core/FlexibleSheetState {
 	public static final field $stable I
-	public fun <init> (ZZZLcom/skydoves/flexible/core/FlexibleSheetSize;ZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetValue;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (ZZZLcom/skydoves/flexible/core/FlexibleSheetSize;ZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetValue;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZLcom/skydoves/flexible/core/FlexibleSheetSize;ZZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetValue;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (ZZZLcom/skydoves/flexible/core/FlexibleSheetSize;ZZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetValue;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun animateTo (Lcom/skydoves/flexible/core/FlexibleSheetValue;FLandroidx/compose/animation/core/AnimationSpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun animateTo$default (Lcom/skydoves/flexible/core/FlexibleSheetState;Lcom/skydoves/flexible/core/FlexibleSheetValue;FLandroidx/compose/animation/core/AnimationSpec;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun fullyExpand (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -52,6 +52,7 @@ public final class com/skydoves/flexible/core/FlexibleSheetState {
 	public final fun getSkipSlightlyExpanded ()Z
 	public final fun getSwipeableState ()Lcom/skydoves/flexible/core/SwipeableV2State;
 	public final fun getTargetValue ()Lcom/skydoves/flexible/core/FlexibleSheetValue;
+	public final fun getUsePopup ()Z
 	public final fun hide (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun intermediatelyExpand (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun isAnimatingContent ()Landroidx/compose/runtime/State;
@@ -68,7 +69,7 @@ public final class com/skydoves/flexible/core/FlexibleSheetState {
 }
 
 public final class com/skydoves/flexible/core/FlexibleSheetStateKt {
-	public static final fun rememberFlexibleBottomSheetState (ZZZLcom/skydoves/flexible/core/FlexibleSheetValue;ZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetSize;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/skydoves/flexible/core/FlexibleSheetState;
+	public static final fun rememberFlexibleBottomSheetState (ZZZLcom/skydoves/flexible/core/FlexibleSheetValue;ZZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetSize;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Lcom/skydoves/flexible/core/FlexibleSheetState;
 }
 
 public final class com/skydoves/flexible/core/FlexibleSheetValue : java/lang/Enum {

--- a/flexible-core/api/desktop/flexible-core.api
+++ b/flexible-core/api/desktop/flexible-core.api
@@ -28,8 +28,8 @@ public final class com/skydoves/flexible/core/FlexibleSheetSize$Companion {
 
 public final class com/skydoves/flexible/core/FlexibleSheetState {
 	public static final field $stable I
-	public fun <init> (ZZZLcom/skydoves/flexible/core/FlexibleSheetSize;ZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetValue;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (ZZZLcom/skydoves/flexible/core/FlexibleSheetSize;ZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetValue;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZLcom/skydoves/flexible/core/FlexibleSheetSize;ZZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetValue;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (ZZZLcom/skydoves/flexible/core/FlexibleSheetSize;ZZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetValue;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun animateTo (Lcom/skydoves/flexible/core/FlexibleSheetValue;FLandroidx/compose/animation/core/AnimationSpec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun animateTo$default (Lcom/skydoves/flexible/core/FlexibleSheetState;Lcom/skydoves/flexible/core/FlexibleSheetValue;FLandroidx/compose/animation/core/AnimationSpec;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun fullyExpand (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -46,6 +46,7 @@ public final class com/skydoves/flexible/core/FlexibleSheetState {
 	public final fun getSkipSlightlyExpanded ()Z
 	public final fun getSwipeableState ()Lcom/skydoves/flexible/core/SwipeableV2State;
 	public final fun getTargetValue ()Lcom/skydoves/flexible/core/FlexibleSheetValue;
+	public final fun getUsePopup ()Z
 	public final fun hide (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun intermediatelyExpand (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun isAnimatingContent ()Landroidx/compose/runtime/State;
@@ -62,7 +63,7 @@ public final class com/skydoves/flexible/core/FlexibleSheetState {
 }
 
 public final class com/skydoves/flexible/core/FlexibleSheetStateKt {
-	public static final fun rememberFlexibleBottomSheetState (ZZZLcom/skydoves/flexible/core/FlexibleSheetValue;ZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetSize;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/skydoves/flexible/core/FlexibleSheetState;
+	public static final fun rememberFlexibleBottomSheetState (ZZZLcom/skydoves/flexible/core/FlexibleSheetValue;ZZZZLandroidx/compose/animation/core/AnimationSpec;Lcom/skydoves/flexible/core/FlexibleSheetSize;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)Lcom/skydoves/flexible/core/FlexibleSheetState;
 }
 
 public final class com/skydoves/flexible/core/FlexibleSheetValue : java/lang/Enum {

--- a/flexible-core/build.gradle.kts
+++ b/flexible-core/build.gradle.kts
@@ -93,6 +93,12 @@ kotlin {
       }
     }
 
+    val commonTest by getting {
+      dependencies {
+        implementation(kotlin("test"))
+      }
+    }
+
     val androidMain by getting {
       dependencies {
         implementation(libs.androidx.lifecycle.viewmodel)

--- a/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetState.kt
+++ b/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetState.kt
@@ -51,6 +51,10 @@ import kotlin.jvm.JvmName
  * will be dismissed upon touching outside of the sheet. If set to false, the bottom sheet allows interaction with the screen, permitting actions outside of the sheet.
  * expand to the [FlexibleSheetValue.FullyExpanded] state and move to the [FlexibleSheetValue.IntermediatelyExpanded] if available, either
  * programmatically or by user interaction.
+ * @param usePopup Whether to render the bottom sheet in a popup window. If true (default), the sheet
+ * uses a separate window which appears above all content including navigation drawers. If false,
+ * the sheet renders inline within the composable hierarchy, allowing it to respect the z-order
+ * of other components like navigation drawers.
  */
 @Stable
 public class FlexibleSheetState(
@@ -61,6 +65,7 @@ public class FlexibleSheetState(
   public val containSystemBars: Boolean,
   public val allowNestedScroll: Boolean,
   public val isModal: Boolean,
+  public val usePopup: Boolean = true,
   public val animateSpec: AnimationSpec<Float>,
   initialValue: FlexibleSheetValue = FlexibleSheetValue.Hidden,
   confirmValueChange: (FlexibleSheetValue) -> Boolean = { true },
@@ -315,6 +320,7 @@ public class FlexibleSheetState(
       containSystemBars: Boolean,
       allowNestedScroll: Boolean,
       isModal: Boolean,
+      usePopup: Boolean = true,
       animateSpec: AnimationSpec<Float>,
       confirmValueChange: (FlexibleSheetValue) -> Boolean,
     ) = Saver<FlexibleSheetState, FlexibleSheetValue>(
@@ -325,6 +331,7 @@ public class FlexibleSheetState(
           skipIntermediatelyExpanded = skipIntermediatelyExpanded,
           skipSlightlyExpanded = skipSlightlyExpanded,
           isModal = isModal,
+          usePopup = usePopup,
           initialValue = savedValue,
           animateSpec = animateSpec,
           flexibleSheetSize = flexibleSheetSize,
@@ -473,6 +480,7 @@ public fun rememberFlexibleBottomSheetState(
   skipSlightlyExpanded: Boolean = true,
   initialValue: FlexibleSheetValue = FlexibleSheetValue.Hidden,
   isModal: Boolean = false,
+  usePopup: Boolean = true,
   containSystemBars: Boolean = true,
   allowNestedScroll: Boolean = true,
   animateSpec: AnimationSpec<Float> = SwipeableV2Defaults.AnimationSpec,
@@ -490,6 +498,7 @@ public fun rememberFlexibleBottomSheetState(
   skipSlightlyExpanded = skipSlightlyExpanded,
   initialValue = initialValue,
   isModal = isModal,
+  usePopup = usePopup,
   animateSpec = animateSpec,
   confirmValueChange = confirmValueChange,
   flexibleSheetSize = flexibleSheetSize,
@@ -503,6 +512,7 @@ private fun rememberFlexibleSheetState(
   skipIntermediatelyExpanded: Boolean = false,
   skipSlightlyExpanded: Boolean = false,
   isModal: Boolean = true,
+  usePopup: Boolean = true,
   confirmValueChange: (FlexibleSheetValue) -> Boolean = { true },
   animateSpec: AnimationSpec<Float> = SwipeableV2Defaults.AnimationSpec,
   initialValue: FlexibleSheetValue = FlexibleSheetValue.Hidden,
@@ -514,12 +524,14 @@ private fun rememberFlexibleSheetState(
     skipHiddenState,
     skipIntermediatelyExpanded,
     skipSlightlyExpanded,
+    usePopup,
     confirmValueChange,
     saver = FlexibleSheetState.Saver(
       skipHiddenState = skipHiddenState,
       skipIntermediatelyExpanded = skipIntermediatelyExpanded,
       skipSlightlyExpanded = skipSlightlyExpanded,
       isModal = isModal,
+      usePopup = usePopup,
       animateSpec = animateSpec,
       flexibleSheetSize = flexibleSheetSize,
       containSystemBars = containSystemBars,
@@ -532,6 +544,7 @@ private fun rememberFlexibleSheetState(
       skipIntermediatelyExpanded = skipIntermediatelyExpanded,
       skipSlightlyExpanded = skipSlightlyExpanded,
       isModal = isModal,
+      usePopup = usePopup,
       initialValue = initialValue,
       animateSpec = animateSpec,
       confirmValueChange = confirmValueChange,

--- a/flexible-core/src/commonTest/kotlin/com/skydoves/flexible/core/FlexibleSheetStateTest.kt
+++ b/flexible-core/src/commonTest/kotlin/com/skydoves/flexible/core/FlexibleSheetStateTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Designed and developed by 2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.flexible.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class FlexibleSheetStateTest {
+
+  @Test
+  internal fun usePopup_defaults_to_true() {
+    val state = FlexibleSheetState(
+      skipHiddenState = false,
+      skipIntermediatelyExpanded = false,
+      skipSlightlyExpanded = false,
+      flexibleSheetSize = FlexibleSheetSize(),
+      containSystemBars = true,
+      allowNestedScroll = true,
+      isModal = true,
+      animateSpec = SwipeableV2Defaults.AnimationSpec,
+    )
+
+    assertTrue(state.usePopup, "usePopup should default to true")
+  }
+
+  @Test
+  internal fun usePopup_can_be_set_to_false() {
+    val state = FlexibleSheetState(
+      skipHiddenState = false,
+      skipIntermediatelyExpanded = false,
+      skipSlightlyExpanded = false,
+      flexibleSheetSize = FlexibleSheetSize(),
+      containSystemBars = true,
+      allowNestedScroll = true,
+      isModal = true,
+      usePopup = false,
+      animateSpec = SwipeableV2Defaults.AnimationSpec,
+    )
+
+    assertFalse(state.usePopup, "usePopup should be false when explicitly set")
+  }
+
+  @Test
+  internal fun usePopup_can_be_set_to_true_explicitly() {
+    val state = FlexibleSheetState(
+      skipHiddenState = false,
+      skipIntermediatelyExpanded = false,
+      skipSlightlyExpanded = false,
+      flexibleSheetSize = FlexibleSheetSize(),
+      containSystemBars = true,
+      allowNestedScroll = true,
+      isModal = true,
+      usePopup = true,
+      animateSpec = SwipeableV2Defaults.AnimationSpec,
+    )
+
+    assertTrue(state.usePopup, "usePopup should be true when explicitly set")
+  }
+
+  @Test
+  internal fun usePopup_is_independent_of_isModal() {
+    val modalWithPopup = FlexibleSheetState(
+      skipHiddenState = false,
+      skipIntermediatelyExpanded = false,
+      skipSlightlyExpanded = false,
+      flexibleSheetSize = FlexibleSheetSize(),
+      containSystemBars = true,
+      allowNestedScroll = true,
+      isModal = true,
+      usePopup = true,
+      animateSpec = SwipeableV2Defaults.AnimationSpec,
+    )
+
+    val modalWithoutPopup = FlexibleSheetState(
+      skipHiddenState = false,
+      skipIntermediatelyExpanded = false,
+      skipSlightlyExpanded = false,
+      flexibleSheetSize = FlexibleSheetSize(),
+      containSystemBars = true,
+      allowNestedScroll = true,
+      isModal = true,
+      usePopup = false,
+      animateSpec = SwipeableV2Defaults.AnimationSpec,
+    )
+
+    val nonModalWithPopup = FlexibleSheetState(
+      skipHiddenState = false,
+      skipIntermediatelyExpanded = false,
+      skipSlightlyExpanded = false,
+      flexibleSheetSize = FlexibleSheetSize(),
+      containSystemBars = true,
+      allowNestedScroll = true,
+      isModal = false,
+      usePopup = true,
+      animateSpec = SwipeableV2Defaults.AnimationSpec,
+    )
+
+    val nonModalWithoutPopup = FlexibleSheetState(
+      skipHiddenState = false,
+      skipIntermediatelyExpanded = false,
+      skipSlightlyExpanded = false,
+      flexibleSheetSize = FlexibleSheetSize(),
+      containSystemBars = true,
+      allowNestedScroll = true,
+      isModal = false,
+      usePopup = false,
+      animateSpec = SwipeableV2Defaults.AnimationSpec,
+    )
+
+    assertTrue(modalWithPopup.isModal)
+    assertTrue(modalWithPopup.usePopup)
+
+    assertTrue(modalWithoutPopup.isModal)
+    assertFalse(modalWithoutPopup.usePopup)
+
+    assertFalse(nonModalWithPopup.isModal)
+    assertTrue(nonModalWithPopup.usePopup)
+
+    assertFalse(nonModalWithoutPopup.isModal)
+    assertFalse(nonModalWithoutPopup.usePopup)
+  }
+
+  @Test
+  internal fun flexibleSheetSize_default_values_are_correct() {
+    val defaultSize = FlexibleSheetSize()
+
+    assertEquals(1.0f, defaultSize.fullyExpanded)
+    assertEquals(0.5f, defaultSize.intermediatelyExpanded)
+    assertEquals(0.25f, defaultSize.slightlyExpanded)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new `usePopup` parameter to `FlexibleSheetState` that controls whether the bottom sheet renders in a popup window or inline within the composable hierarchy
- When `usePopup = false`, the bottom sheet renders inline, properly respecting the z-order of navigation drawers
- Defaults to `true` for backward compatibility

## Problem

The FlexibleBottomSheet was rendering above navigation drawers because it uses a popup window via `WindowManager`. Any separate window will always appear above content in the parent window, regardless of the window type.

## Solution

Added an inline rendering mode that can be enabled by setting `usePopup = false`:

```kotlin
rememberFlexibleBottomSheetState(
  isModal = true,
  usePopup = false,  // Renders inline, drawer appears above bottom sheet
  // ... other params
)
```

## Trade-offs

| Mode | Behavior |
|------|----------|
| `usePopup = true` (default) | Bottom sheet renders above all content, useful for overlaying Google Maps etc. |
| `usePopup = false` | Bottom sheet renders inline, respects navigation drawer z-order |

## Test plan

- [ ] Verify bottom sheet with `usePopup = true` renders above all content (default behavior unchanged)
- [ ] Verify bottom sheet with `usePopup = false` renders below navigation drawer
- [ ] Test modal and non-modal sheets with both settings
- [ ] Verify swipe gestures and dismiss behavior work correctly in both modes

Fixes #75