### PR TITLE
fix: resolve FlexibleSheetSize.WrapContent when modal = false (#95)

### DIFF
--- a/flexible-bottomsheet-material/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material/FlexibleBottomSheet.kt
+++ b/flexible-bottomsheet-material/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material/FlexibleBottomSheet.kt
@@ -217,13 +217,21 @@ public fun FlexibleBottomSheet(
         Modifier.fillMaxSize()
       }
     } else {
-      Modifier.height(
-        if (isDragging || isAnimationRunning) {
-          fullyExpandedHeight
-        } else {
-          expectedSheetSize
-        },
-      )
+      if (flexibleSheetSize.hasWrapContent && contentHeightPx <= 0f) {
+        // Content not yet measured: provide full screen height so the Column can expand
+        // to its natural size and report it via onSizeChanged. Without this, the tiny
+        // placeholder height (0.01 * screenHeight) constrains the Column and prevents
+        // content from ever being measured — causing a deadlock.
+        Modifier.fillMaxWidth().height(screenHeightSize)
+      } else {
+        Modifier.height(
+          if (isDragging || isAnimationRunning) {
+            fullyExpandedHeight
+          } else {
+            expectedSheetSize
+          },
+        )
+      }
     }
 
     // Hide sheet until content is measured when using wrap content mode

--- a/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
+++ b/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
@@ -220,13 +220,21 @@ public fun FlexibleBottomSheet(
         Modifier.fillMaxSize()
       }
     } else {
-      Modifier.height(
-        if (isDragging || isAnimationRunning) {
-          fullyExpandedHeight
-        } else {
-          expectedSheetSize
-        },
-      )
+      if (flexibleSheetSize.hasWrapContent && contentHeightPx <= 0f) {
+        // Content not yet measured: provide full screen height so the Column can expand
+        // to its natural size and report it via onSizeChanged. Without this, the tiny
+        // placeholder height (0.01 * screenHeight) constrains the Column and prevents
+        // content from ever being measured — causing a deadlock.
+        Modifier.fillMaxWidth().height(screenHeightSize)
+      } else {
+        Modifier.height(
+          if (isDragging || isAnimationRunning) {
+            fullyExpandedHeight
+          } else {
+            expectedSheetSize
+          },
+        )
+      }
     }
 
     // Hide sheet until content is measured when using wrap content mode


### PR DESCRIPTION
## Guidelines
Version 0.2.0 has issues with FlexibleSheetSize.WrapContent when modal = false even in the demo app.

PR contains a fix.
