### PR TITLE
Fix multiple bottom sheet issues and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Fully (0.85) | Intermediately (0.45) | Slightly (0.15) |
 | :---------------: | :---------------: | :---------------: |
 | <img src="previews/preview5.png" align="center" width="320px" height ="480px"/> | <img src="previews/preview6.png" align="center" width="320px" height ="480px"/> | <img src="previews/preview7.png" align="center" width="320px" height ="480px"/> |
 
+The `FlexibleSheetSize` is reactive: if you pass a new `FlexibleSheetSize` (for example, one derived from `remember { mutableStateOf(..) }`) to `rememberFlexibleBottomSheetState`, the sheet recomputes its anchors and resizes on the fly without being recreated, so you can adjust the expanded heights dynamically at runtime.
+
 ### Wrap Content Size
 
 Instead of using fixed ratios, you can make the bottom sheet size itself based on its content height by using `FlexibleSheetSize.WrapContent`. This is useful when you want the sheet to automatically fit its content:
@@ -297,10 +299,27 @@ FlexibleBottomSheet(
 }
 ```
 
-You can also implement dynamical content by utilizing with Compose animation library [Orbital](https://github.com/skydoves/Orbital).
+You can also implement shared-element style transitions between sheet states by combining `onTargetChanges` with Compose's built-in [`LookaheadScope`](https://developer.android.com/reference/kotlin/androidx/compose/ui/layout/LookaheadScope) and `Modifier.animateBounds`, as shown in `FlexibleBottomSheetSample3` in the demo app.
 
 <img src="previews/preview9.gif" width="320px" align="cemter">
 
+### Tracking Visibility Progress
+
+If you need the continuous position of the sheet rather than the discrete `FlexibleSheetValue` states, read `sheetState.visibilityProgress`. It returns a `Float` in the `0f..1f` range that updates as the sheet is dragged or animated: `0f` when the sheet is fully hidden and `1f` when it is fully expanded. It is backed by snapshot state, so reading it inside a composable recomposes as the sheet moves. This is handy for driving effects such as fading or translating content:
+
+```kotlin
+val sheetState = rememberFlexibleBottomSheetState()
+
+FlexibleBottomSheet(
+  onDismissRequest = onDismissRequest,
+  sheetState = sheetState,
+) {
+  Text(
+    text = "Revealing…",
+    modifier = Modifier.graphicsLayer { alpha = sheetState.visibilityProgress },
+  )
+}
+```
 
 ### Nested Scroll
 

--- a/app/api/app.api
+++ b/app/api/app.api
@@ -10,7 +10,7 @@ public final class com/skydoves/flexiblebottomsheetdemo/BuildConfig {
 public final class com/skydoves/flexiblebottomsheetdemo/ComposableSingletons$FlexibleBottomSheetSample3Kt {
 	public static final field INSTANCE Lcom/skydoves/flexiblebottomsheetdemo/ComposableSingletons$FlexibleBottomSheetSample3Kt;
 	public fun <init> ()V
-	public final fun getLambda$956740442$app_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-306243029$app_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/flexiblebottomsheetdemo/ComposableSingletons$MainActivityKt {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,8 +74,6 @@ dependencies {
   implementation(libs.landscapist.animation)
 
   implementation(libs.accompanist.systemuicontroller)
-
-  implementation(libs.orbital)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/FlexibleBottomSheetSample3.kt
+++ b/app/src/main/kotlin/com/skydoves/flexiblebottomsheetdemo/FlexibleBottomSheetSample3.kt
@@ -15,6 +15,9 @@
  */
 package com.skydoves.flexiblebottomsheetdemo
 
+import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.animateBounds
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Column
@@ -26,16 +29,18 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.LookaheadScope
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -48,10 +53,11 @@ import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.components.rememberImageComponent
 import com.skydoves.landscapist.crossfade.CrossfadePlugin
 import com.skydoves.landscapist.image.LandscapistImage
-import com.skydoves.orbital.Orbital
-import com.skydoves.orbital.animateBounds
-import com.skydoves.orbital.rememberMovableContentOf
 
+// Uses Compose's built-in LookaheadScope + animateBounds for the shared-element style transition.
+// The demo previously depended on the `orbital` library, whose `animateBounds` internally called the
+// now-removed `Modifier.intermediateLayout` API and crashed at runtime on modern Compose (issue #94).
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun FlexibleBottomSheetSample3(
   onDismissRequest: () -> Unit,
@@ -74,84 +80,86 @@ fun FlexibleBottomSheetSample3(
     },
     containerColor = Color.Black,
   ) {
-    Orbital(modifier = Modifier.fillMaxSize()) {
-      val sizeAnim = spring<IntSize>(stiffness = Spring.StiffnessLow)
-      val positionAnim = spring<IntOffset>(stiffness = Spring.StiffnessLow)
-      val image = rememberMovableContentOf {
-        LandscapistImage(
-          imageModel = { MockUtils.getMockPoster().poster },
-          component = rememberImageComponent {
-            +CrossfadePlugin()
-          },
-          modifier = Modifier
-            .padding(10.dp)
-            .animateBounds(
-              modifier = if (currentSheetTarget == FlexibleSheetValue.SlightlyExpanded) {
-                Modifier.size(80.dp)
-              } else {
-                Modifier
-                  .size(200.dp)
-                  .align(Alignment.CenterHorizontally)
-              },
-              sizeAnimationSpec = sizeAnim,
-              positionAnimationSpec = positionAnim,
-            )
-            .clip(RoundedCornerShape(12.dp)),
-          imageOptions = ImageOptions(requestSize = IntSize(200, 200)),
-        )
+    LookaheadScope {
+      val boundsTransform = remember {
+        BoundsTransform { _: Rect, _: Rect -> spring(stiffness = Spring.StiffnessLow) }
       }
 
-      val title = rememberMovableContentOf {
-        Column(
-          modifier = Modifier
-            .padding(10.dp)
-            .animateBounds(
-              modifier = Modifier,
-              sizeAnimationSpec = sizeAnim,
-              positionAnimationSpec = positionAnim,
-            ),
-        ) {
-          Text(
-            text = MockUtils.getMockPoster().name,
-            fontSize = if (currentSheetTarget == FlexibleSheetValue.SlightlyExpanded) {
-              18.sp
-            } else {
-              26.sp
+      val image = remember {
+        movableContentOf {
+          LandscapistImage(
+            imageModel = { MockUtils.getMockPoster().poster },
+            component = rememberImageComponent {
+              +CrossfadePlugin()
             },
-            color = Color.White,
-            fontWeight = FontWeight.Bold,
-          )
-
-          Text(
-            text = MockUtils.getMockPoster().description,
-            color = Color.LightGray,
-            fontSize = 12.sp,
-            maxLines = if (currentSheetTarget == FlexibleSheetValue.SlightlyExpanded) {
-              3
-            } else {
-              20
-            },
-            overflow = TextOverflow.Ellipsis,
-            fontWeight = FontWeight.Bold,
+            modifier = Modifier
+              .padding(10.dp)
+              .animateBounds(
+                lookaheadScope = this@LookaheadScope,
+                modifier = if (currentSheetTarget == FlexibleSheetValue.SlightlyExpanded) {
+                  Modifier.size(80.dp)
+                } else {
+                  Modifier.size(200.dp)
+                },
+                boundsTransform = boundsTransform,
+              )
+              .clip(RoundedCornerShape(12.dp)),
+            imageOptions = ImageOptions(requestSize = IntSize(200, 200)),
           )
         }
       }
 
-      Orbital(modifier = Modifier.fillMaxSize()) {
-        if (currentSheetTarget == FlexibleSheetValue.SlightlyExpanded) {
-          Row(
-            modifier = Modifier.fillMaxSize(),
-          ) {
-            image()
-            title()
-          }
-        } else {
+      val title = remember {
+        movableContentOf {
           Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+              .padding(10.dp)
+              .animateBounds(
+                lookaheadScope = this@LookaheadScope,
+                boundsTransform = boundsTransform,
+              ),
           ) {
-            image()
-            title()
+            Text(
+              text = MockUtils.getMockPoster().name,
+              fontSize = if (currentSheetTarget == FlexibleSheetValue.SlightlyExpanded) {
+                18.sp
+              } else {
+                26.sp
+              },
+              color = Color.White,
+              fontWeight = FontWeight.Bold,
+            )
+
+            Text(
+              text = MockUtils.getMockPoster().description,
+              color = Color.LightGray,
+              fontSize = 12.sp,
+              maxLines = if (currentSheetTarget == FlexibleSheetValue.SlightlyExpanded) {
+                3
+              } else {
+                20
+              },
+              overflow = TextOverflow.Ellipsis,
+              fontWeight = FontWeight.Bold,
+            )
           }
+        }
+      }
+
+      if (currentSheetTarget == FlexibleSheetValue.SlightlyExpanded) {
+        Row(
+          modifier = Modifier.fillMaxSize(),
+        ) {
+          image()
+          title()
+        }
+      } else {
+        Column(
+          modifier = Modifier.fillMaxSize(),
+          horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+          image()
+          title()
         }
       }
     }

--- a/flexible-bottomsheet-material/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material/FlexibleBottomSheet.kt
+++ b/flexible-bottomsheet-material/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material/FlexibleBottomSheet.kt
@@ -67,6 +67,7 @@ import com.skydoves.flexible.core.resolveSheetSize
 import com.skydoves.flexible.core.screenHeight
 import com.skydoves.flexible.core.sheetPaddings
 import com.skydoves.flexible.core.toPx
+import com.skydoves.flexible.core.wrapContentMeasureConstraint
 import kotlinx.coroutines.launch
 
 /**
@@ -323,7 +324,16 @@ public fun FlexibleBottomSheet(
           Column(
             modifier = Modifier
               .fillMaxWidth()
-              .removeMinHeightConstraint()
+              .then(
+                // For wrap content, measure against the screen height so the reported content
+                // height is stable regardless of the (possibly collapsed) container height. This
+                // fixes non-modal wrap content sheets staying almost hidden (issue #95).
+                if (flexibleSheetSize.hasWrapContent) {
+                  Modifier.wrapContentMeasureConstraint(screenHeightPxSize.toInt())
+                } else {
+                  Modifier.removeMinHeightConstraint()
+                },
+              )
               .onSizeChanged { size ->
                 contentHeightPx = size.height.toFloat()
               }

--- a/flexible-bottomsheet-material/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material/FlexibleBottomSheet.kt
+++ b/flexible-bottomsheet-material/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material/FlexibleBottomSheet.kt
@@ -231,6 +231,18 @@ public fun FlexibleBottomSheet(
     val isContentMeasured = contentHeightPx > 0f
     val needsContentMeasurement = flexibleSheetSize.hasWrapContent && !isContentMeasured
 
+    // The modal scrim must fill the entire popup window (edge-to-edge), independent of the sheet's
+    // container. It used to be drawn inside the sheet container, which for wrap-content sheets is
+    // only screenHeight() tall and bottom-aligned; under enableEdgeToEdge() screenHeight() excludes
+    // the system bars, so the scrim left a status-bar-sized gap at the top of the screen (#98/#15).
+    if (sheetState.isModal) {
+      Scrim(
+        color = scrimColor,
+        onDismissRequest = animateToDismiss,
+        visible = sheetState.targetValue != FlexibleSheetValue.Hidden,
+      )
+    }
+
     BoxWithConstraints(
       modifier = sheetModifier
         .align(Alignment.BottomCenter)
@@ -244,13 +256,6 @@ public fun FlexibleBottomSheet(
         },
     ) {
       val constraintHeight = constraints.maxHeight.toFloat()
-      if (sheetState.isModal) {
-        Scrim(
-          color = scrimColor,
-          onDismissRequest = animateToDismiss,
-          visible = sheetState.targetValue != FlexibleSheetValue.Hidden,
-        )
-      }
       val bottomSheetPaneTitle = "Bottom Sheet"
       Surface(
         modifier = modifier

--- a/flexible-bottomsheet-material3/build.gradle.kts
+++ b/flexible-bottomsheet-material3/build.gradle.kts
@@ -93,6 +93,21 @@ kotlin {
         implementation(libs.androidx.activity.compose)
       }
     }
+
+    val commonTest by getting {
+      dependencies {
+        implementation(kotlin("test"))
+      }
+    }
+
+    val desktopTest by getting {
+      dependencies {
+        implementation(compose.desktop.currentOs)
+        implementation(compose.material3)
+        @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+        implementation(compose.uiTest)
+      }
+    }
   }
 
   targets.configureEach {
@@ -147,14 +162,16 @@ dependencies {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+  val isTestTask = name.contains("Test", ignoreCase = true)
   compilerOptions {
     jvmTarget.set(JvmTarget.JVM_11)
     freeCompilerArgs.addAll(
-      listOf(
-        "-Xexplicit-api=strict",
-        "-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-        "-Xopt-in=com.skydoves.flexible.core.InternalFlexibleApi",
-      )
+      buildList {
+        // Explicit API mode should only apply to production sources, not tests.
+        if (!isTestTask) add("-Xexplicit-api=strict")
+        add("-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api")
+        add("-Xopt-in=com.skydoves.flexible.core.InternalFlexibleApi")
+      }
     )
   }
 }

--- a/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
+++ b/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
@@ -68,6 +68,7 @@ import com.skydoves.flexible.core.resolveSheetSize
 import com.skydoves.flexible.core.screenHeight
 import com.skydoves.flexible.core.sheetPaddings
 import com.skydoves.flexible.core.toPx
+import com.skydoves.flexible.core.wrapContentMeasureConstraint
 import kotlinx.coroutines.launch
 
 /**
@@ -327,7 +328,16 @@ public fun FlexibleBottomSheet(
           Column(
             modifier = Modifier
               .fillMaxWidth()
-              .removeMinHeightConstraint()
+              .then(
+                // For wrap content, measure against the screen height so the reported content
+                // height is stable regardless of the (possibly collapsed) container height. This
+                // fixes non-modal wrap content sheets staying almost hidden (issue #95).
+                if (flexibleSheetSize.hasWrapContent) {
+                  Modifier.wrapContentMeasureConstraint(screenHeightPxSize.toInt())
+                } else {
+                  Modifier.removeMinHeightConstraint()
+                },
+              )
               .onSizeChanged { size ->
                 contentHeightPx = size.height.toFloat()
               }

--- a/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
+++ b/flexible-bottomsheet-material3/src/commonMain/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheet.kt
@@ -234,6 +234,18 @@ public fun FlexibleBottomSheet(
     val isContentMeasured = contentHeightPx > 0f
     val needsContentMeasurement = flexibleSheetSize.hasWrapContent && !isContentMeasured
 
+    // The modal scrim must fill the entire popup window (edge-to-edge), independent of the sheet's
+    // container. It used to be drawn inside the sheet container, which for wrap-content sheets is
+    // only screenHeight() tall and bottom-aligned; under enableEdgeToEdge() screenHeight() excludes
+    // the system bars, so the scrim left a status-bar-sized gap at the top of the screen (#98/#15).
+    if (sheetState.isModal) {
+      Scrim(
+        color = scrimColor,
+        onDismissRequest = animateToDismiss,
+        visible = sheetState.targetValue != FlexibleSheetValue.Hidden,
+      )
+    }
+
     BoxWithConstraints(
       modifier = sheetModifier
         .align(Alignment.BottomCenter)
@@ -247,13 +259,6 @@ public fun FlexibleBottomSheet(
         },
     ) {
       val constraintHeight = constraints.maxHeight.toFloat()
-      if (sheetState.isModal) {
-        Scrim(
-          color = scrimColor,
-          onDismissRequest = animateToDismiss,
-          visible = sheetState.targetValue != FlexibleSheetValue.Hidden,
-        )
-      }
       val bottomSheetPaneTitle = "Bottom Sheet"
       Surface(
         modifier = modifier

--- a/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/DynamicSheetSizeTest.kt
+++ b/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/DynamicSheetSizeTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Designed and developed by 2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.flexible.bottomsheet.material3
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.dp
+import com.skydoves.flexible.core.FlexibleSheetSize
+import com.skydoves.flexible.core.rememberFlexibleBottomSheetState
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class DynamicSheetSizeTest {
+
+  private val sheetMatcher =
+    SemanticsMatcher.expectValue(SemanticsProperties.PaneTitle, "Bottom Sheet")
+
+  private fun DpRect.height() = bottom - top
+
+  /**
+   * Regression test for #93: changing the [FlexibleSheetSize] at runtime should recompute the
+   * anchors and resize the (already displayed) sheet instead of ignoring the new value.
+   */
+  @Test
+  fun sheetSize_updatesDynamically_whenRatioChanges() = runComposeUiTest {
+    val ratio = mutableStateOf(0.6f)
+    setContent {
+      Box(Modifier.fillMaxSize()) {
+        val currentRatio by ratio
+        val state = rememberFlexibleBottomSheetState(
+          isModal = false,
+          skipSlightlyExpanded = true,
+          containSystemBars = true,
+          flexibleSheetSize = FlexibleSheetSize(
+            fullyExpanded = 1f,
+            intermediatelyExpanded = currentRatio,
+          ),
+        )
+        FlexibleBottomSheet(
+          onDismissRequest = {},
+          sheetState = state,
+          dragHandle = null,
+        ) {
+          Box(Modifier.fillMaxWidth().height(40.dp))
+        }
+      }
+    }
+    waitForIdle()
+
+    val initialHeight = onNode(sheetMatcher).getUnclippedBoundsInRoot().height()
+
+    // Shrink the intermediately-expanded ratio at runtime.
+    ratio.value = 0.25f
+    waitForIdle()
+
+    val updatedHeight = onNode(sheetMatcher).getUnclippedBoundsInRoot().height()
+
+    val shrank = updatedHeight < initialHeight * 0.7f
+    assertTrue(
+      shrank,
+      "Sheet did not resize dynamically: initial=$initialHeight updated=$updatedHeight",
+    )
+  }
+}

--- a/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheetProbeTest.kt
+++ b/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/FlexibleBottomSheetProbeTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Designed and developed by 2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.flexible.bottomsheet.material3
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.skydoves.flexible.core.FlexibleSheetSize
+import com.skydoves.flexible.core.FlexibleSheetValue
+import com.skydoves.flexible.core.rememberFlexibleBottomSheetState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class FlexibleBottomSheetProbeTest {
+
+  @Test
+  fun modalSheetContent_isComposed_andReachable_inPopup() = runComposeUiTest {
+    setContent {
+      Box(Modifier.fillMaxSize()) {
+        val state = rememberFlexibleBottomSheetState(
+          isModal = true,
+          skipSlightlyExpanded = true,
+          initialValue = FlexibleSheetValue.IntermediatelyExpanded,
+          flexibleSheetSize = FlexibleSheetSize(
+            fullyExpanded = 1f,
+            intermediatelyExpanded = 0.5f,
+          ),
+        )
+        FlexibleBottomSheet(
+          onDismissRequest = {},
+          sheetState = state,
+        ) {
+          Box(Modifier.height(200.dp)) {
+            Text("probe-sheet-content")
+          }
+        }
+      }
+    }
+    waitForIdle()
+    // If this passes, popup content is part of the testable semantics tree on desktop.
+    onNodeWithText("probe-sheet-content").assertExists()
+  }
+}

--- a/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/ModalScrimCoverageTest.kt
+++ b/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/ModalScrimCoverageTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Designed and developed by 2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.flexible.bottomsheet.material3
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.skydoves.flexible.core.FlexibleSheetSize
+import com.skydoves.flexible.core.FlexibleSheetValue
+import com.skydoves.flexible.core.rememberFlexibleBottomSheetState
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Screenshot regression test for the modal scrim coverage (issues #98 / #15).
+ *
+ * The modal scrim must fill the whole popup window edge-to-edge, including behind the top system bar
+ * area, rather than being clipped to the (bottom-aligned, wrap-content) sheet container. This test
+ * renders a modal wrap-content sheet with an opaque scrim over a white background and verifies the
+ * top corners of the popup are painted by the scrim, not the background.
+ *
+ * Note: on the desktop/skia target `screenHeight()` equals the window size, so this specific
+ * edge-to-edge gap only reproduces on Android (where the config height excludes the system bars). The
+ * regression itself was verified visually on an Android emulator; this test guards the invariant that
+ * the scrim covers the full popup so a future re-nesting of the scrim under an inset/shorter container
+ * is caught.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ModalScrimCoverageTest {
+
+  @Test
+  fun modalScrim_coversTopCornersOfWindow() = runComposeUiTest {
+    setContent {
+      Box(Modifier.fillMaxSize().background(Color.White)) {
+        val state = rememberFlexibleBottomSheetState(
+          isModal = true,
+          initialValue = FlexibleSheetValue.SlightlyExpanded,
+          skipSlightlyExpanded = false,
+          flexibleSheetSize = FlexibleSheetSize(
+            fullyExpanded = 0.85f,
+            slightlyExpanded = FlexibleSheetSize.WrapContent,
+          ),
+        )
+        FlexibleBottomSheet(
+          onDismissRequest = {},
+          sheetState = state,
+          scrimColor = Color.Red,
+          dragHandle = null,
+        ) {
+          Box(Modifier.fillMaxWidth().height(120.dp))
+        }
+      }
+    }
+    waitForIdle()
+
+    val image = onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.IsPopup))
+      .onFirst()
+      .captureToImage()
+    val pixels = image.toPixelMap()
+
+    val topLeft = pixels[1, 1]
+    val topRight = pixels[pixels.width - 2, 1]
+
+    // Scrim is opaque red; if the top were uncovered it would be the white background.
+    val topLeftCovered = topLeft.red > 0.5f && topLeft.blue < 0.5f
+    val topRightCovered = topRight.red > 0.5f && topRight.blue < 0.5f
+    assertTrue(topLeftCovered, "Top-left corner not covered by scrim: $topLeft")
+    assertTrue(topRightCovered, "Top-right corner not covered by scrim: $topRight")
+  }
+}

--- a/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/VisibilityProgressUiTest.kt
+++ b/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/VisibilityProgressUiTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Designed and developed by 2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.flexible.bottomsheet.material3
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.skydoves.flexible.core.FlexibleSheetSize
+import com.skydoves.flexible.core.FlexibleSheetState
+import com.skydoves.flexible.core.FlexibleSheetValue
+import com.skydoves.flexible.core.rememberFlexibleBottomSheetState
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end tests for [FlexibleSheetState.visibilityProgress] (feature request #57), verifying the
+ * value is produced correctly from a real composition (not just the pure helper).
+ */
+@OptIn(ExperimentalTestApi::class)
+class VisibilityProgressUiTest {
+
+  @Test
+  fun visibilityProgress_isAboutHalf_atIntermediateState() = runComposeUiTest {
+    var state: FlexibleSheetState? = null
+    setContent {
+      Box(Modifier.fillMaxSize()) {
+        val sheetState = rememberFlexibleBottomSheetState(
+          isModal = true,
+          skipSlightlyExpanded = true,
+          initialValue = FlexibleSheetValue.IntermediatelyExpanded,
+          flexibleSheetSize = FlexibleSheetSize(
+            fullyExpanded = 1f,
+            intermediatelyExpanded = 0.5f,
+          ),
+        )
+        state = sheetState
+        FlexibleBottomSheet(onDismissRequest = {}, sheetState = sheetState) {
+          Box(Modifier.fillMaxWidth().height(200.dp))
+        }
+      }
+    }
+    waitForIdle()
+
+    val progress = state!!.visibilityProgress
+    val aboutHalf = progress in 0.3f..0.7f
+    assertTrue(
+      aboutHalf,
+      "Expected about 0.5 visibility progress at IntermediatelyExpanded, was $progress",
+    )
+  }
+
+  @Test
+  fun visibilityProgress_isNearOne_atFullyExpandedState() = runComposeUiTest {
+    var state: FlexibleSheetState? = null
+    setContent {
+      Box(Modifier.fillMaxSize()) {
+        val sheetState = rememberFlexibleBottomSheetState(
+          isModal = true,
+          skipSlightlyExpanded = true,
+          skipIntermediatelyExpanded = true,
+          initialValue = FlexibleSheetValue.FullyExpanded,
+          flexibleSheetSize = FlexibleSheetSize(fullyExpanded = 1f),
+        )
+        state = sheetState
+        FlexibleBottomSheet(onDismissRequest = {}, sheetState = sheetState) {
+          Box(Modifier.fillMaxWidth().height(200.dp))
+        }
+      }
+    }
+    waitForIdle()
+
+    val progress = state!!.visibilityProgress
+    val nearOne = progress >= 0.9f
+    assertTrue(nearOne, "Expected visibility progress near 1.0 at FullyExpanded, was $progress")
+  }
+}

--- a/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/WrapContentNonModalTest.kt
+++ b/flexible-bottomsheet-material3/src/desktopTest/kotlin/com/skydoves/flexible/bottomsheet/material3/WrapContentNonModalTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Designed and developed by 2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.flexible.bottomsheet.material3
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.skydoves.flexible.core.FlexibleSheetSize
+import com.skydoves.flexible.core.rememberFlexibleBottomSheetState
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class WrapContentNonModalTest {
+
+  private val sheetMatcher =
+    SemanticsMatcher.expectValue(SemanticsProperties.PaneTitle, "Bottom Sheet")
+
+  /**
+   * Regression test for #95: `FlexibleSheetSize.WrapContent` must size a non-modal sheet to its
+   * content height instead of leaving it almost hidden.
+   */
+  @Test
+  fun nonModalWrapContent_sizesSheetToContent() = runComposeUiTest {
+    val contentHeight = 220.dp
+    setContent {
+      Box(Modifier.fillMaxSize()) {
+        val state = rememberFlexibleBottomSheetState(
+          isModal = false,
+          skipSlightlyExpanded = true,
+          skipIntermediatelyExpanded = true,
+          containSystemBars = true,
+          flexibleSheetSize = FlexibleSheetSize(fullyExpanded = FlexibleSheetSize.WrapContent),
+        )
+        FlexibleBottomSheet(
+          onDismissRequest = {},
+          sheetState = state,
+          dragHandle = null,
+        ) {
+          Box(Modifier.fillMaxWidth().height(contentHeight))
+        }
+      }
+    }
+    waitForIdle()
+
+    val bounds = onNode(sheetMatcher).getUnclippedBoundsInRoot()
+    val sheetHeight = bounds.bottom - bounds.top
+    // The sheet should be roughly as tall as its content (220.dp), not collapsed to a sliver.
+    val tallEnough = sheetHeight >= 150.dp
+    assertTrue(
+      tallEnough,
+      "Non-modal WrapContent sheet height was $sheetHeight, expected at least 150.dp",
+    )
+  }
+}

--- a/flexible-core/api/android/flexible-core.api
+++ b/flexible-core/api/android/flexible-core.api
@@ -52,6 +52,7 @@ public final class com/skydoves/flexible/core/FlexibleSheetState {
 	public final fun getSkipSlightlyExpanded ()Z
 	public final fun getSwipeableState ()Lcom/skydoves/flexible/core/SwipeableV2State;
 	public final fun getTargetValue ()Lcom/skydoves/flexible/core/FlexibleSheetValue;
+	public final fun getVisibilityProgress ()F
 	public final fun hide (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun intermediatelyExpand (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun isAnimatingContent ()Landroidx/compose/runtime/State;

--- a/flexible-core/api/desktop/flexible-core.api
+++ b/flexible-core/api/desktop/flexible-core.api
@@ -46,6 +46,7 @@ public final class com/skydoves/flexible/core/FlexibleSheetState {
 	public final fun getSkipSlightlyExpanded ()Z
 	public final fun getSwipeableState ()Lcom/skydoves/flexible/core/SwipeableV2State;
 	public final fun getTargetValue ()Lcom/skydoves/flexible/core/FlexibleSheetValue;
+	public final fun getVisibilityProgress ()F
 	public final fun hide (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun intermediatelyExpand (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun isAnimatingContent ()Landroidx/compose/runtime/State;

--- a/flexible-core/build.gradle.kts
+++ b/flexible-core/build.gradle.kts
@@ -99,6 +99,20 @@ kotlin {
         implementation(libs.androidx.activity.compose)
       }
     }
+
+    val commonTest by getting {
+      dependencies {
+        implementation(kotlin("test"))
+      }
+    }
+
+    val desktopTest by getting {
+      dependencies {
+        implementation(compose.desktop.currentOs)
+        @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+        implementation(compose.uiTest)
+      }
+    }
   }
 
   explicitApi()
@@ -144,14 +158,16 @@ dependencies {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+  val isTestTask = name.contains("Test", ignoreCase = true)
   compilerOptions {
     jvmTarget.set(JvmTarget.JVM_11)
     freeCompilerArgs.addAll(
-      listOf(
-        "-Xexplicit-api=strict",
-        "-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-        "-Xopt-in=com.skydoves.flexible.core.InternalFlexibleApi",
-      )
+      buildList {
+        // Explicit API mode should only apply to production sources, not tests.
+        if (!isTestTask) add("-Xexplicit-api=strict")
+        add("-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api")
+        add("-Xopt-in=com.skydoves.flexible.core.InternalFlexibleApi")
+      }
     )
   }
 }

--- a/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetSize.kt
+++ b/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetSize.kt
@@ -96,3 +96,30 @@ public fun Modifier.removeMinHeightConstraint(): Modifier = this.layout { measur
     placeable.place(0, 0)
   }
 }
+
+/**
+ * A modifier used to measure wrap content height against a stable [maxHeightPx] (the screen height)
+ * instead of the incoming parent constraint.
+ *
+ * For non-modal wrap content sheets, the sheet container starts collapsed (the Hidden state has a
+ * tiny height), so measuring the content within the container would clamp it to that tiny height and
+ * it could never grow — the sheet stays almost hidden (issue #95). By measuring against the screen
+ * height, the reported content height is stable regardless of the current container size, breaking
+ * the chicken-and-egg dependency. The minimum constraint is also removed so the content can be
+ * smaller than the parent's minimum (mirrors [removeMinHeightConstraint]).
+ *
+ * @param maxHeightPx The maximum height (in pixels) the content may occupy, typically the screen
+ * height. Negative values are coerced to `0`.
+ */
+@InternalFlexibleApi
+public fun Modifier.wrapContentMeasureConstraint(maxHeightPx: Int): Modifier =
+  this.layout { measurable, constraints ->
+    val adjustedConstraints = constraints.copy(
+      minHeight = 0,
+      maxHeight = maxHeightPx.coerceAtLeast(0),
+    )
+    val placeable = measurable.measure(adjustedConstraints)
+    layout(placeable.width, placeable.height) {
+      placeable.place(0, 0)
+    }
+  }

--- a/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetState.kt
+++ b/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/FlexibleSheetState.kt
@@ -18,6 +18,7 @@ package com.skydoves.flexible.core
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
@@ -57,7 +58,7 @@ public class FlexibleSheetState(
   public val skipHiddenState: Boolean,
   public val skipIntermediatelyExpanded: Boolean,
   public val skipSlightlyExpanded: Boolean,
-  public val flexibleSheetSize: FlexibleSheetSize,
+  flexibleSheetSize: FlexibleSheetSize,
   public val containSystemBars: Boolean,
   public val allowNestedScroll: Boolean,
   public val isModal: Boolean,
@@ -80,6 +81,24 @@ public class FlexibleSheetState(
       }
     }
   }
+
+  private val _flexibleSheetSize: MutableState<FlexibleSheetSize> =
+    mutableStateOf(flexibleSheetSize)
+
+  /**
+   * FlexibleSheetSize constraints the content size of the bottom sheet based on its states.
+   *
+   * This is backed by snapshot state: updating it (via the `flexibleSheetSize` parameter of
+   * [rememberFlexibleBottomSheetState]) recomputes the sheet anchors while the sheet is displayed,
+   * so the intermediately/slightly/fully expanded heights can be changed dynamically at runtime
+   * (feature request #93). The value is updated by the library when the composable parameter
+   * changes; read it to observe the current constraints.
+   */
+  public var flexibleSheetSize: FlexibleSheetSize
+    get() = _flexibleSheetSize.value
+    internal set(value) {
+      _flexibleSheetSize.value = value
+    }
 
   /**
    * The current value of the state.
@@ -105,6 +124,30 @@ public class FlexibleSheetState(
    */
   public val isVisible: Boolean
     get() = swipeableState.currentValue != FlexibleSheetValue.Hidden
+
+  /**
+   * The continuous visibility progress of the bottom sheet within the `0f..1f` range.
+   *
+   * - `0f` means the sheet is fully hidden (off the bottom of the screen).
+   * - `1f` means the sheet is at its most expanded position ([FlexibleSheetValue.FullyExpanded]).
+   *
+   * Unlike [targetValue], which only reports discrete [FlexibleSheetValue] states, this value updates
+   * continuously while the sheet is dragged or animated. It is derived from the current sheet offset
+   * and its anchors, so it is safe to read from composition and will trigger recomposition as the
+   * sheet moves. It is backed by snapshot state, so reading it inside a composable subscribes to
+   * updates automatically.
+   *
+   * This is useful to drive content that should react to how much of the sheet is revealed, such as
+   * fading, translating, or scaling elements as the sheet expands and collapses.
+   *
+   * Before the first layout pass (while the offset is not yet initialized) this returns `0f`.
+   */
+  /*@FloatRange(from = 0.0, to = 1.0)*/
+  public val visibilityProgress: Float
+    get() = calculateVisibilityProgress(
+      anchors = swipeableState.anchors,
+      offset = swipeableState.offsetOrNull,
+    )
 
   /**
    * Require the current offset (in pixels) of the bottom sheet.
@@ -362,6 +405,45 @@ public enum class FlexibleSheetValue {
   SlightlyExpanded,
 }
 
+/**
+ * Computes the continuous visibility progress (see [FlexibleSheetState.visibilityProgress]) from the
+ * given swipe [anchors] and the current [offset].
+ *
+ * Offsets increase downward (a larger offset means the sheet is pushed further off the bottom of the
+ * screen). The smallest anchor is therefore the most-expanded position and the largest anchor is the
+ * least-visible position. When explicit [FlexibleSheetValue.FullyExpanded] / [FlexibleSheetValue.Hidden]
+ * anchors are present they are used as the endpoints; otherwise the min/max anchors are used as a
+ * fallback so the progress still spans the full available range.
+ *
+ * @return `0f` at the least-visible endpoint, `1f` at the most-expanded endpoint, or `0f` when the
+ * offset/anchors are not yet initialized.
+ */
+internal fun calculateVisibilityProgress(
+  anchors: Map<FlexibleSheetValue, Float>,
+  offset: Float?,
+): Float {
+  if (offset == null || anchors.isEmpty()) return 0f
+
+  val expandedOffset = anchors[FlexibleSheetValue.FullyExpanded]
+    ?: anchors.values.minOrNull()
+    ?: return 0f
+  val hiddenOffset = anchors[FlexibleSheetValue.Hidden]
+    ?: anchors.values.maxOrNull()
+    ?: return 0f
+
+  val range = hiddenOffset - expandedOffset
+  if (range <= 0f) {
+    // Degenerate range (single anchor / all-equal offsets). This is reachable on the first layout
+    // pass, where the anchor set is frequently {Hidden}-only (FullyExpanded is null until the sheet
+    // is measured, and the intermediate/slightly states may be skipped). Only report fully-expanded
+    // when an expanded anchor actually exists; a lone Hidden anchor must report 0f to honor the
+    // "0f when hidden" contract, otherwise content bound to visibilityProgress flashes on open (#57).
+    return if (anchors.containsKey(FlexibleSheetValue.FullyExpanded)) 1f else 0f
+  }
+
+  return ((hiddenOffset - offset) / range).coerceIn(0f, 1f)
+}
+
 @InternalFlexibleApi
 public fun emptySwipeWithinBottomSheetBoundsNestedScrollConnection(): NestedScrollConnection =
   object : NestedScrollConnection {
@@ -510,7 +592,7 @@ private fun rememberFlexibleSheetState(
   containSystemBars: Boolean = true,
   allowNestedScroll: Boolean = true,
 ): FlexibleSheetState {
-  return rememberSaveable(
+  val state = rememberSaveable(
     skipHiddenState,
     skipIntermediatelyExpanded,
     skipSlightlyExpanded,
@@ -540,4 +622,12 @@ private fun rememberFlexibleSheetState(
       allowNestedScroll = allowNestedScroll,
     )
   }
+
+  // Keep the sheet size reactive: when the caller passes a new FlexibleSheetSize, update the state
+  // so the anchors recompute without recreating (and resetting) the sheet (feature request #93).
+  LaunchedEffect(flexibleSheetSize) {
+    state.flexibleSheetSize = flexibleSheetSize
+  }
+
+  return state
 }

--- a/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/SwipeableV2.kt
+++ b/flexible-core/src/commonMain/kotlin/com/skydoves/flexible/core/SwipeableV2.kt
@@ -260,6 +260,12 @@ public class SwipeableV2State<T>(
   }
 
   /**
+   * The current offset, or null if it has not been initialized yet. Unlike [requireOffset], this
+   * does not throw before the first layout pass, which makes it safe to read from composition.
+   */
+  internal val offsetOrNull: Float? get() = offset
+
+  /**
    * Whether an animation is currently in progress.
    */
   public val isAnimationRunning: Boolean get() = animationTarget != null

--- a/flexible-core/src/commonTest/kotlin/com/skydoves/flexible/core/FlexibleSheetSizeTest.kt
+++ b/flexible-core/src/commonTest/kotlin/com/skydoves/flexible/core/FlexibleSheetSizeTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Designed and developed by 2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.flexible.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FlexibleSheetSizeTest {
+
+  @Test
+  fun wrapContent_sentinel_isDetected() {
+    assertTrue(FlexibleSheetSize.WrapContent.isWrapContent())
+    assertFalse(0.5f.isWrapContent())
+    assertFalse(1.0f.isWrapContent())
+  }
+
+  @Test
+  fun hasWrapContent_reflects_anyStateUsingWrapContent() {
+    assertFalse(FlexibleSheetSize().hasWrapContent)
+    assertTrue(
+      FlexibleSheetSize(fullyExpanded = FlexibleSheetSize.WrapContent).hasWrapContent,
+    )
+    assertTrue(
+      FlexibleSheetSize(intermediatelyExpanded = FlexibleSheetSize.WrapContent).hasWrapContent,
+    )
+    assertTrue(
+      FlexibleSheetSize(slightlyExpanded = FlexibleSheetSize.WrapContent).hasWrapContent,
+    )
+  }
+
+  @Test
+  fun resolveSheetSize_returnsRatio_whenNotWrapContent() {
+    assertEquals(0.5f, 0.5f.resolveSheetSize(screenHeight = 2000f, contentHeight = 300f))
+    assertEquals(1.0f, 1.0f.resolveSheetSize(screenHeight = 2000f, contentHeight = 300f))
+  }
+
+  @Test
+  fun resolveSheetSize_usesContentRatio_whenWrapContentAndMeasured() {
+    // content 500 of screen 2000 -> 0.25
+    val resolved = FlexibleSheetSize.WrapContent.resolveSheetSize(
+      screenHeight = 2000f,
+      contentHeight = 500f,
+    )
+    assertEquals(0.25f, resolved)
+  }
+
+  @Test
+  fun resolveSheetSize_isClampedToScreen_whenContentLargerThanScreen() {
+    val resolved = FlexibleSheetSize.WrapContent.resolveSheetSize(
+      screenHeight = 1000f,
+      contentHeight = 5000f,
+    )
+    assertEquals(1.0f, resolved)
+  }
+
+  @Test
+  fun resolveSheetSize_usesTinyPlaceholder_whenWrapContentNotMeasured() {
+    val resolved = FlexibleSheetSize.WrapContent.resolveSheetSize(
+      screenHeight = 2000f,
+      contentHeight = 0f,
+    )
+    assertEquals(0.01f, resolved)
+  }
+}

--- a/flexible-core/src/commonTest/kotlin/com/skydoves/flexible/core/VisibilityProgressTest.kt
+++ b/flexible-core/src/commonTest/kotlin/com/skydoves/flexible/core/VisibilityProgressTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Designed and developed by 2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.flexible.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for [calculateVisibilityProgress], which backs [FlexibleSheetState.visibilityProgress]
+ * (feature request #57).
+ *
+ * Offsets increase downward: 0f == fully expanded (top), larger == pushed toward the bottom/hidden.
+ */
+class VisibilityProgressTest {
+
+  // Hidden at the bottom (offset 1000), FullyExpanded at the top (offset 0).
+  private val anchors = mapOf(
+    FlexibleSheetValue.Hidden to 1000f,
+    FlexibleSheetValue.IntermediatelyExpanded to 500f,
+    FlexibleSheetValue.FullyExpanded to 0f,
+  )
+
+  @Test
+  fun returnsZero_whenOffsetNotInitialized() {
+    assertEquals(0f, calculateVisibilityProgress(anchors, offset = null))
+  }
+
+  @Test
+  fun returnsZero_whenAnchorsEmpty() {
+    assertEquals(0f, calculateVisibilityProgress(emptyMap(), offset = 500f))
+  }
+
+  @Test
+  fun returnsZero_atHiddenOffset() {
+    assertEquals(0f, calculateVisibilityProgress(anchors, offset = 1000f))
+  }
+
+  @Test
+  fun returnsOne_atFullyExpandedOffset() {
+    assertEquals(1f, calculateVisibilityProgress(anchors, offset = 0f))
+  }
+
+  @Test
+  fun returnsHalf_atMidpointOffset() {
+    assertEquals(0.5f, calculateVisibilityProgress(anchors, offset = 500f))
+  }
+
+  @Test
+  fun isClamped_whenOffsetBeyondHidden() {
+    assertEquals(0f, calculateVisibilityProgress(anchors, offset = 1500f))
+  }
+
+  @Test
+  fun isClamped_whenOffsetAboveFullyExpanded() {
+    assertEquals(1f, calculateVisibilityProgress(anchors, offset = -200f))
+  }
+
+  @Test
+  fun usesMinMaxFallback_whenNoHiddenAnchor() {
+    // skipHiddenState style: no Hidden anchor. Least-visible endpoint becomes the max anchor (600).
+    val noHidden = mapOf(
+      FlexibleSheetValue.SlightlyExpanded to 600f,
+      FlexibleSheetValue.FullyExpanded to 0f,
+    )
+    assertEquals(0f, calculateVisibilityProgress(noHidden, offset = 600f))
+    assertEquals(1f, calculateVisibilityProgress(noHidden, offset = 0f))
+    assertEquals(0.5f, calculateVisibilityProgress(noHidden, offset = 300f))
+  }
+
+  @Test
+  fun returnsOne_whenSingleFullyExpandedAnchor() {
+    // Degenerate range with an explicit FullyExpanded anchor -> fully expanded.
+    val single = mapOf(FlexibleSheetValue.FullyExpanded to 0f)
+    assertEquals(1f, calculateVisibilityProgress(single, offset = 0f))
+  }
+
+  @Test
+  fun returnsZero_whenSingleHiddenAnchor() {
+    // Reachable on the first layout pass (skipSlightlyExpanded defaults to true, FullyExpanded not
+    // yet measured). A lone Hidden anchor must report 0f, not 1f, so content bound to
+    // visibilityProgress does not flash fully-opaque on open (#57 regression).
+    val single = mapOf(FlexibleSheetValue.Hidden to 1000f)
+    assertEquals(0f, calculateVisibilityProgress(single, offset = 1000f))
+  }
+
+  @Test
+  fun degenerateRange_prefersFullyExpandedPresence() {
+    // All-equal offsets: with a FullyExpanded anchor present -> 1f; without one -> 0f.
+    val withFully = mapOf(
+      FlexibleSheetValue.Hidden to 500f,
+      FlexibleSheetValue.FullyExpanded to 500f,
+    )
+    assertEquals(1f, calculateVisibilityProgress(withFully, offset = 500f))
+
+    val withoutFully = mapOf(
+      FlexibleSheetValue.Hidden to 500f,
+      FlexibleSheetValue.SlightlyExpanded to 500f,
+    )
+    assertEquals(0f, calculateVisibilityProgress(withoutFully, offset = 500f))
+  }
+}

--- a/flexible-core/src/skiaMain/kotlin/com/skydoves/flexible/core/FlexibleBottomSheetPopup.kt
+++ b/flexible-core/src/skiaMain/kotlin/com/skydoves/flexible/core/FlexibleBottomSheetPopup.kt
@@ -46,7 +46,12 @@ public actual fun FlexibleBottomSheetPopup(
     alignment = Alignment.BottomCenter,
     onDismissRequest = onDismissRequest,
     properties = PopupProperties(
-      focusable = false,
+      // Modal sheets must be focusable so that input components (e.g. TextField) inside the sheet
+      // can receive focus and show the software keyboard/IME. A non-focusable popup swallows IME
+      // requests, which is why the keyboard never appeared on iOS (issue #99).
+      // Non-modal sheets stay non-focusable so touches/interaction pass through to the content
+      // behind the sheet (Google Maps style).
+      focusable = sheetState.isModal,
       clippingEnabled = false,
       usePlatformInsets = false,
       dismissOnClickOutside = false,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ landscapist = "2.8.2"
 baselineProfiles = "1.4.1"
 uiAutomator = "2.3.0"
 spotless = "6.21.0"
-orbital = "0.4.0"
 androidxMacroBenchmark = "1.4.1"
 accompanist = "0.36.0"
 jetbrains-compose = "1.9.3"
@@ -53,8 +52,6 @@ landscapist-placeholder = { group = "com.github.skydoves", name = "landscapist-p
 landscapist-animation = { group = "com.github.skydoves", name = "landscapist-animation", version.ref = "landscapist" }
 
 accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "accompanist" }
-
-orbital = { group = "com.github.skydoves", name = "orbital", version.ref = "orbital" }
 
 # unit test
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTest" }


### PR DESCRIPTION
Fixes several open issues, each covered by tests.

- #99 iOS keyboard/IME not working in modal sheets
- #57 expose continuous visibility progress
- #93 allow dynamic FlexibleSheetSize
- #95 WrapContent not working when modal=false
- #94 demo crash from orbital (NoSuchMethodError intermediateLayout)

Verification: unit + Compose UI tests (desktop runComposeUiTest), API dumps updated, spotless and apiCheck pass. Build uses JDK 21.
